### PR TITLE
Refactor/#72 홈 / 커피 추천 UI 리팩토링

### DIFF
--- a/LastCoffee/LastCoffee/Util/Constants.swift
+++ b/LastCoffee/LastCoffee/Util/Constants.swift
@@ -8,3 +8,7 @@
 import Foundation
 import UIKit
 
+public struct Constants {
+    // SE 기기일 떄 바텀의 safeAreaLayoutGuide가 탭바 높이보다 아래에 있어서 추가 패딩이 필요함
+    public static var seBottomExtraPadding: CGFloat = 30
+}

--- a/LastCoffee/LastCoffee/Util/Constants.swift
+++ b/LastCoffee/LastCoffee/Util/Constants.swift
@@ -11,4 +11,5 @@ import UIKit
 public struct Constants {
     // SE 기기일 떄 바텀의 safeAreaLayoutGuide가 탭바 높이보다 아래에 있어서 추가 패딩이 필요함
     public static var seBottomExtraPadding: CGFloat = 30
+    public static var isSeDevice: Bool = DynamicPadding.superViewHeight <= 667
 }

--- a/LastCoffee/LastCoffee/Views/Home/HomeView.swift
+++ b/LastCoffee/LastCoffee/Views/Home/HomeView.swift
@@ -88,7 +88,7 @@ class HomeView: UIView {
         }
         
         btnRecommendDrink.snp.makeConstraints { make in
-            make.bottom.equalTo(safeAreaLayoutGuide).inset(DynamicPadding.dynamicValue(37) + Constants.seBottomExtraPadding)
+            make.bottom.equalTo(safeAreaLayoutGuide).inset(DynamicPadding.dynamicValue(37) + (Constants.isSeDevice ? Constants.seBottomExtraPadding : 0))
             make.width.equalTo(DynamicPadding.dynamicValuebyWidth(174))
             make.height.equalTo(DynamicPadding.dynamicValue(54))
             make.centerX.equalToSuperview()

--- a/LastCoffee/LastCoffee/Views/Home/HomeView.swift
+++ b/LastCoffee/LastCoffee/Views/Home/HomeView.swift
@@ -13,7 +13,7 @@ class HomeView: UIView {
     
     // 닉네임 라벨
     private lazy var lblNickname = UILabel().then { lbl in
-        lbl.text = "\(nickname)님, 오늘도 좋은 하루 보내세요 : )"
+        lbl.text = "\(nickname)님, 행복 가득한 하루 되세요 : )"
         lbl.font = .ptdSemiBoldFont(ofSize: 18)
         lbl.textAlignment = .left
     }
@@ -37,7 +37,7 @@ class HomeView: UIView {
     
     public let lblEmptyMenu = UILabel().then { lbl in
         lbl.text = "아직 추천 받은 메뉴가 없어요"
-        lbl.textColor = UIColor(hex: "111111")
+        lbl.textColor = UIColor(hex: "5D5D5D")
         lbl.textAlignment = .center
         lbl.font = .ptdMediumFont(ofSize: 14)
         lbl.isHidden = true
@@ -79,18 +79,18 @@ class HomeView: UIView {
         collectionView.snp.makeConstraints { make in
             make.top.equalTo(lblNickname.snp.bottom).offset(17)
             make.horizontalEdges.equalToSuperview()
-            make.bottom.equalTo(btnRecommendDrink.snp.top)
+            make.bottom.equalTo(btnRecommendDrink.snp.top).offset(-(DynamicPadding.dynamicValue(34)))
         }
         
         lblEmptyMenu.snp.makeConstraints { make in
-            make.bottom.equalTo(btnRecommendDrink.snp.top).offset(-81)
+            make.bottom.equalTo(btnRecommendDrink.snp.top).offset(-(DynamicPadding.dynamicValue(80)))
             make.centerX.equalToSuperview()
         }
         
         btnRecommendDrink.snp.makeConstraints { make in
-            make.bottom.equalTo(safeAreaLayoutGuide).inset(52)
-            make.width.equalTo(192)
-            make.height.equalTo(54)
+            make.bottom.equalTo(safeAreaLayoutGuide).inset(DynamicPadding.dynamicValue(37) + Constants.seBottomExtraPadding)
+            make.width.equalTo(DynamicPadding.dynamicValuebyWidth(174))
+            make.height.equalTo(DynamicPadding.dynamicValue(54))
             make.centerX.equalToSuperview()
         }
     }
@@ -98,7 +98,7 @@ class HomeView: UIView {
     // 레아이웃 provider
     private func createLayout() -> UICollectionViewCompositionalLayout{
         let config = UICollectionViewCompositionalLayoutConfiguration()
-        config.interSectionSpacing = 22
+        config.interSectionSpacing = DynamicPadding.dynamicValue(22)
         return UICollectionViewCompositionalLayout(sectionProvider: { sectionIndex, _ in
             switch sectionIndex {
             case 0: // 인기 메뉴
@@ -117,7 +117,7 @@ class HomeView: UIView {
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         item.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 16)
         
-        let groupSize = NSCollectionLayoutSize(widthDimension: .absolute(DynamicPadding.superViewWidth - 32), heightDimension: .absolute(200))
+        let groupSize = NSCollectionLayoutSize(widthDimension: .absolute(DynamicPadding.superViewWidth - 32), heightDimension: .absolute(DynamicPadding.dynamicValue(200)))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
         
         let section = NSCollectionLayoutSection(group: group)
@@ -139,7 +139,7 @@ class HomeView: UIView {
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         item.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 10, bottom: 0, trailing: 0)
         
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.3), heightDimension: .absolute(140))
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.3), heightDimension: .absolute(DynamicPadding.dynamicValue(140)))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
         
         let section = NSCollectionLayoutSection(group: group)

--- a/LastCoffee/LastCoffee/Views/Recommand/RecommandDrinkView.swift
+++ b/LastCoffee/LastCoffee/Views/Recommand/RecommandDrinkView.swift
@@ -30,7 +30,7 @@ class RecommendDrinkView: UIView {
     }
     
     public let btnCheck = CustomButton().then { btn in
-        btn.configure(title: "확인", titleColor: .white, font: .ptdSemiBoldFont(ofSize: 18), radius: 10, backgroundColor: .mainColor ?? .tintColor, isEnabled: true)
+        btn.configure(title: "확인", titleColor: .white, font: .ptdSemiBoldFont(ofSize: 18), radius: 10, backgroundColor: .mainColor, isEnabled: true)
     }
     
     init(selectedHour: String) {
@@ -55,14 +55,14 @@ class RecommendDrinkView: UIView {
     
     private func setUI() {
         lblTitle.snp.makeConstraints { make in
-            make.top.equalTo(safeAreaLayoutGuide).inset(32)
+            make.top.equalTo(safeAreaLayoutGuide).inset(DynamicPadding.dynamicValue(32))
             make.horizontalEdges.equalToSuperview().inset(20)
         }
         
         collectionView.snp.makeConstraints { make in
-            make.top.equalTo(lblTitle.snp.bottom).offset(46)
+            make.top.equalTo(lblTitle.snp.bottom).offset(DynamicPadding.dynamicValue(46))
             make.horizontalEdges.equalToSuperview()
-            make.bottom.equalTo(btnCheck.snp.top)
+            make.bottom.equalTo(btnCheck.snp.top).offset(-(DynamicPadding.dynamicValue(76)))
         }
         
         btnCheck.snp.makeConstraints { make in
@@ -83,13 +83,13 @@ class RecommendDrinkView: UIView {
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         item.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 14)
         
-        let groupSize = NSCollectionLayoutSize(widthDimension: .absolute(286), heightDimension: .absolute(396))
+        let groupSize = NSCollectionLayoutSize(widthDimension: .absolute(DynamicPadding.dynamicValuebyWidth(286)), heightDimension: .absolute(DynamicPadding.dynamicValue(396)))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
         
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .continuous
         
-        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 45, bottom: 0, trailing: 45)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: DynamicPadding.dynamicValuebyWidth(45), bottom: 0, trailing: DynamicPadding.dynamicValuebyWidth(45))
         
         return section
     }


### PR DESCRIPTION
## 🔗 관련 이슈

연관된 이슈 번호를 적어주세요. (예: #123)

#72 

---

## 📌 PR 요약

PR에 대한 간략한 설명을 작성해주세요.  
(예: 해당 변경 사항의 목적이나 주요 내용)

홈 / 커피 추천 UI 리팩토링

---

## 📑 작업 내용

작업의 세부 내용을 작성해주세요.
1. 홈 뷰 UI 리팩토링
- 커피 추천 버튼에 바텀 safeAreaLayoutGuide에 inset을 줘도 버튼이 탭바에 가려짐
- Constants에 SE 디바이스인지 디바이스 Height으로 판단 후 패딩 추가
- 컬렉션뷰의 크기를 기기 반응형으로 수정

2. 커피 추천 UI 리팩토링 
- 컬렉션뷰의 크기를 기기 반응형으로 수정

---

## 스크린샷 (선택)
순서대로 SE, 13mini, 16 pro max 입니다.
<table>
  <tr>
    <td colspan="3" style="text-align: center; font-weight: bold;">
      홈뷰
    </td>
  </tr>
  <tr>
    <td style="text-align: center;"><img src="https://github.com/user-attachments/assets/d186cf1c-f26b-42e9-87f5-54e35c69820a" width="200"/></td>
    <td style="text-align: center;"><img src="https://github.com/user-attachments/assets/19ec9850-873e-4a04-9a29-5a32c1c90318" width="200"/></td>
    <td style="text-align: center;"><img src="https://github.com/user-attachments/assets/348161c1-22a5-41c3-b25f-e8fb060ed483" width="200"/></td>
  </tr>
</table>

<table>
  <tr>
    <td colspan="3" style="text-align: center; font-weight: bold;">
      시간 선택뷰
    </td>
  </tr>
  <tr>
    <td style="text-align: center;"><img src="https://github.com/user-attachments/assets/4c6617f5-583c-4f9d-a8b8-ef0f3dd3cb65" width="200"/></td>
    <td style="text-align: center;"><img src="https://github.com/user-attachments/assets/5bf12c72-c90f-48a8-bb87-3c12fc91dd88" width="200"/></td>
    <td style="text-align: center;"><img src="https://github.com/user-attachments/assets/ddf07963-6d69-49e2-8bfa-c88643b6e6ab" width="200"/></td>
  </tr>
</table>

<table>
  <tr>
    <td colspan="3" style="text-align: center; font-weight: bold;">
      커피 추천뷰
    </td>
  </tr>
  <tr>
    <td style="text-align: center;">
      <img src="https://github.com/user-attachments/assets/fd373498-1948-49d0-99a5-d09042ef30f6" width="200"/>
    </td>
    <td style="text-align: center;">
      <img src="https://github.com/user-attachments/assets/6f0d3d18-5680-4645-847a-362eb0659d79" width="200"/>
    </td>
    <td style="text-align: center;">
      <img src="https://github.com/user-attachments/assets/7bc5386a-9af5-481c-9a13-228b6ad08a42" width="200"/>
    </td>
  </tr>
</table>

---

## 💡 추가 참고 사항

PR에 대해 추가적으로 논의하거나 참고해야 할 내용을 작성해주세요.
(예: 변경사항이 코드베이스에 미치는 영향, 테스트 방법 등)
